### PR TITLE
Publisher configuration

### DIFF
--- a/src/nbs_bl/configuration.py
+++ b/src/nbs_bl/configuration.py
@@ -7,7 +7,7 @@ from .run_engine import create_run_engine
 from .hw import loadDevices
 from abc import ABC, abstractmethod
 from os.path import join, exists
-from .tiledWriter import subscribe_tiled_profile
+from .publishers import publish_to_tiled, publish_to_kafka, publish_to_zmq
 from nbs_core.autoconf import load_settings
 try:
     import tomllib
@@ -324,28 +324,16 @@ class InitializeRunEngineStep(InitializationStep):
         )
         if tiled_cfg and tiled_cfg.get("enabled", True):
             self.print_substep("Subscribing to Tiled writer")
-            client = subscribe_tiled_profile(beamline.run_engine, tiled_cfg)
+            client = publish_to_tiled(beamline.run_engine, tiled_cfg, print_substep=self.print_substep)
             context["namespace"]["tiled_writing_client"] = client
 
         kafka_cfg = (beamline.settings.get("kafka", {}))
         if kafka_cfg and kafka_cfg.get("enabled", True):
-            from nslsii import configure_kafka_publisher
+            publish_to_kafka(beamline.run_engine, kafka_cfg, print_substep=self.print_substep)
 
-            name = kafka_cfg.get("name")
-            kafka_file = kafka_cfg.get("config_file", None)
-            self.print_substep(f"Subscribing to Kafka topic: {name}")
-            if kafka_file is not None:
-                configure_kafka_publisher(beamline.run_engine, name, override_config_path=kafka_file)
-            else:
-                configure_kafka_publisher(beamline.run_engine, name)
         zmq_cfg = beamline.settings.get("zmq", {})
         if zmq_cfg and zmq_cfg.get("enabled", True):
-            from bluesky.callbacks.zmq import Publisher
-            hostname = zmq_cfg.get("hostname", "localhost")
-            port = zmq_cfg.get("port", 5577)
-            self.print_substep(f"Subscribing to ZMQ publisher at {hostname}:{port}")
-            publisher = Publisher(f"{hostname}:{port}")
-            beamline.run_engine.subscribe(publisher)
+            publish_to_zmq(beamline.run_engine, zmq_cfg, print_substep=self.print_substep)
 
         return context
 
@@ -398,8 +386,6 @@ class LoadDevicesStep(InitializationStep):
         ns = context.get("namespace")
         # Move all of this to a helper function in hw.py
         devices = loadDevices(device_config, ns, mode="default")
-
-        
 
         for device_name, device_info in devices.items():
             beamline.add_device(device_name, device_info)

--- a/src/nbs_bl/publishers.py
+++ b/src/nbs_bl/publishers.py
@@ -1,6 +1,6 @@
 import os
 
-def subscribe_tiled_profile(run_engine, config):
+def publish_to_tiled(run_engine, config, print_substep=print):
     if "profile" in config:
         from tiled.client import from_profile as create_client
         client_args = [config['profile'],]
@@ -35,3 +35,26 @@ def subscribe_tiled_profile(run_engine, config):
     run_engine.subscribe(callback)
     return client
 
+def publish_to_kafka(run_engine, config, print_substep=print):
+    from nslsii import configure_kafka_publisher
+
+    name = config.get("name")
+    kafka_file = config.get("config_file", None)
+    print_substep(f"Publishing to Kafka topic: {name}")
+    if kafka_file is not None:
+        configure_kafka_publisher(run_engine, name, override_config_path=kafka_file)
+    else:
+        configure_kafka_publisher(run_engine, name)
+
+def publish_to_zmq(run_engine, config, print_substep=print):
+    from bluesky.callbacks.zmq import Publisher, Proxy
+
+    hostname = config.get("hostname", "localhost")
+    port = config.get("port", 5577)
+    start_proxy = config.get("start_proxy", False)
+    if start_proxy:
+        output_port = config.get("output_port", 5578)
+        print_substep(f"Starting ZMQ proxy on {port} and forwarding to {output_port}")
+        Proxy(port, output_port)
+    publisher = Publisher(f"{hostname}:{port}")
+    run_engine.subscribe(publisher)

--- a/src/nbs_bl/publishers.py
+++ b/src/nbs_bl/publishers.py
@@ -59,5 +59,6 @@ def publish_to_zmq(run_engine, config, print_substep=print):
         proxy = Proxy(port, out_port)
         proxy_thread = threading.Thread(target=proxy.start, daemon=True)
         proxy_thread.start()
+    print_substep(f"Subscribing to ZMQ publisher on {hostname}:{port}")
     publisher = Publisher(f"{hostname}:{port}")
     run_engine.subscribe(publisher)

--- a/src/nbs_bl/publishers.py
+++ b/src/nbs_bl/publishers.py
@@ -47,14 +47,17 @@ def publish_to_kafka(run_engine, config, print_substep=print):
         configure_kafka_publisher(run_engine, name)
 
 def publish_to_zmq(run_engine, config, print_substep=print):
+    import threading
     from bluesky.callbacks.zmq import Publisher, Proxy
 
     hostname = config.get("hostname", "localhost")
     port = config.get("port", 5577)
     start_proxy = config.get("start_proxy", False)
     if start_proxy:
-        output_port = config.get("output_port", 5578)
-        print_substep(f"Starting ZMQ proxy on {port} and forwarding to {output_port}")
-        Proxy(port, output_port)
+        out_port = config.get("out_port", port + 1)
+        print_substep(f"Starting ZMQ proxy on {port} and forwarding to {out_port}")
+        proxy = Proxy(port, out_port)
+        proxy_thread = threading.Thread(target=proxy.start, daemon=True)
+        proxy_thread.start()
     publisher = Publisher(f"{hostname}:{port}")
     run_engine.subscribe(publisher)

--- a/src/nbs_bl/tiledWriter.py
+++ b/src/nbs_bl/tiledWriter.py
@@ -1,9 +1,14 @@
 import os
 
 def subscribe_tiled_profile(run_engine, config):
-    from tiled.client import from_profile
-
-    profile = config["profile"]
+    if "profile" in config:
+        from tiled.client import from_profile as create_client
+        client_args = [config['profile'],]
+    elif "uri" in config:
+        from tiled.client import from_uri as create_client
+        client_args = [config['uri'],]
+    else:
+        raise ValueError("Invalid configuration for tiled writer")
     api_key_env = config.get("api_key_env", None)
     catalog_path = config.get("catalog_path", [])
     subscribe_method = config.get("subscribe_method", "post_document")
@@ -14,13 +19,19 @@ def subscribe_tiled_profile(run_engine, config):
         api_key = None
 
     if api_key is not None:
-        client = from_profile(profile, api_key=api_key)
+        client = create_client(*client_args, api_key=api_key)
     else:
-        client = from_profile(profile)
+        client = create_client(*client_args)
     for key in catalog_path:
         client = client[key]
 
-    callback = getattr(client, subscribe_method)
+    if subscribe_method == "post_document":
+        callback = client.post_document
+    elif subscribe_method == "tiled_writer":
+        from bluesky_tiled_plugins import TiledWriter
+        callback = TiledWriter(client)
+    else:
+        raise ValueError(f"Invalid subscribe method: {subscribe_method}")
     run_engine.subscribe(callback)
     return client
 


### PR DESCRIPTION
Configuration for Tiled, Kafka, and ZMQ now split off into one publisher file. Additional configuration options for TiledWriter and ZMQ. Can now start an in-process ZMQ proxy in its own thread.